### PR TITLE
gdb: disable source-highlight

### DIFF
--- a/sysdrv/tools/board/gdb/Makefile
+++ b/sysdrv/tools/board/gdb/Makefile
@@ -69,6 +69,7 @@ all: expat
 			--disable-werror  --enable-static  --without-mpfr  --disable-tui  --without-python  \
 			--without-lzma \
 			--with-expat \
+			--disable-source-highlight \
 			--with-libexpat-prefix=$(CURRENT_DIR)/$(PKG_NAME_EXPAT)/$(PKG_BIN) \
 			--with-zlib ;\
 		make -j$(SYSDRV_JOBS) >/dev/null || exit -1; \
@@ -105,6 +106,7 @@ expat:
 			--enable-ipv6 \
 			--disable-nls \
 			--enable-static \
+			--disable-source-highlight \
 			--disable-shared; \
 		make -j$(SYSDRV_JOBS) >/dev/null || exit -1; \
 		make install > /dev/null; \


### PR DESCRIPTION
Disabled source highlight in board config to avoid compilation errors according to upstream [buildroot patch](https://git.buildroot.net/buildroot/commit/?id=d418f09ab5ce4bc8bb03fcd3722448ef9f5ba3d0) and [discussion](https://lore.kernel.org/buildroot/877cov5bo7.fsf@48ers.dk/T/) and issue #20