### PR TITLE
build.sh:fix oem partition cannot mount

### DIFF
--- a/project/build.sh
+++ b/project/build.sh
@@ -1845,6 +1845,7 @@ function build_firmware(){
 
 	if [ "$RK_BUILD_APP_TO_OEM_PARTITION" = "y" ];then
 		rm -rf $RK_PROJECT_PACKAGE_ROOTFS_DIR/oem/*
+		mkdir -p $RK_PROJECT_PACKAGE_ROOTFS_DIR/oem
 		build_mkimg $GLOBAL_OEM_NAME $RK_PROJECT_PACKAGE_OEM_DIR
 	else
 		mkdir -p $RK_PROJECT_PACKAGE_ROOTFS_DIR/oem

--- a/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Buildroot-RV1103_Luckfox_Pico-IPC.mk
+++ b/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Buildroot-RV1103_Luckfox_Pico-IPC.mk
@@ -27,7 +27,7 @@ export RK_BOOT_MEDIUM=emmc
 export RK_UBOOT_DEFCONFIG_FRAGMENT=rk-emmc.config
 
 # specify post.sh for delete/overlay files
-export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
+# export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
 
 # config partition in environment
 # RK_PARTITION_CMD_IN_ENV format:

--- a/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Buildroot-RV1103_Luckfox_Pico_Mini_A-IPC.mk
+++ b/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Buildroot-RV1103_Luckfox_Pico_Mini_A-IPC.mk
@@ -27,7 +27,7 @@ export RK_BOOT_MEDIUM=emmc
 export RK_UBOOT_DEFCONFIG_FRAGMENT=rk-emmc.config
 
 # specify post.sh for delete/overlay files
-export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
+# export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
 
 # config partition in environment
 # RK_PARTITION_CMD_IN_ENV format:

--- a/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Ubuntu-RV1103_Luckfox_Pico-IPC.mk
+++ b/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Ubuntu-RV1103_Luckfox_Pico-IPC.mk
@@ -27,7 +27,7 @@ export RK_BOOT_MEDIUM=emmc
 export RK_UBOOT_DEFCONFIG_FRAGMENT=rk-emmc.config
 
 # specify post.sh for delete/overlay files
-export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
+# export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
 
 # config partition in environment
 # RK_PARTITION_CMD_IN_ENV format:

--- a/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Ubuntu-RV1103_Luckfox_Pico_Mini_A-IPC.mk
+++ b/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Ubuntu-RV1103_Luckfox_Pico_Mini_A-IPC.mk
@@ -27,7 +27,7 @@ export RK_BOOT_MEDIUM=emmc
 export RK_UBOOT_DEFCONFIG_FRAGMENT=rk-emmc.config
 
 # specify post.sh for delete/overlay files
-export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
+# export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
 
 # config partition in environment
 # RK_PARTITION_CMD_IN_ENV format:

--- a/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Ubuntu-RV1103_Luckfox_Pico_Plus-IPC.mk
+++ b/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Ubuntu-RV1103_Luckfox_Pico_Plus-IPC.mk
@@ -27,7 +27,7 @@ export RK_BOOT_MEDIUM=emmc
 export RK_UBOOT_DEFCONFIG_FRAGMENT=rk-emmc.config
 
 # specify post.sh for delete/overlay files
-export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
+# export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
 
 # config partition in environment
 # RK_PARTITION_CMD_IN_ENV format:

--- a/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Ubuntu-RV1106_Luckfox_Pico_Pro_Max-IPC.mk
+++ b/project/cfg/BoardConfig_IPC/BoardConfig-EMMC-Ubuntu-RV1106_Luckfox_Pico_Pro_Max-IPC.mk
@@ -27,7 +27,7 @@ export RK_BOOT_MEDIUM=emmc
 export RK_UBOOT_DEFCONFIG_FRAGMENT=rk-emmc.config
 
 # specify post.sh for delete/overlay files
-export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
+# export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
 
 # config partition in environment
 # RK_PARTITION_CMD_IN_ENV format:

--- a/project/cfg/BoardConfig_IPC/BoardConfig-SPI_NAND-Buildroot-RV1103_Luckfox_Pico_Mini_B-IPC.mk
+++ b/project/cfg/BoardConfig_IPC/BoardConfig-SPI_NAND-Buildroot-RV1103_Luckfox_Pico_Mini_B-IPC.mk
@@ -27,7 +27,7 @@ export RK_BOOT_MEDIUM=spi_nand
 export RK_UBOOT_DEFCONFIG_FRAGMENT=rk-sfc.config
 
 # specify post.sh for delete/overlay files
-export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
+# export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
 
 # config partition in environment
 # RK_PARTITION_CMD_IN_ENV format:

--- a/project/cfg/BoardConfig_IPC/BoardConfig-SPI_NAND-Buildroot-RV1103_Luckfox_Pico_Plus-IPC.mk
+++ b/project/cfg/BoardConfig_IPC/BoardConfig-SPI_NAND-Buildroot-RV1103_Luckfox_Pico_Plus-IPC.mk
@@ -27,7 +27,7 @@ export RK_BOOT_MEDIUM=spi_nand
 export RK_UBOOT_DEFCONFIG_FRAGMENT=rk-sfc.config
 
 # specify post.sh for delete/overlay files
-export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
+# export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
 
 # config partition in environment
 # RK_PARTITION_CMD_IN_ENV format:

--- a/project/cfg/BoardConfig_IPC/BoardConfig-SPI_NAND-Buildroot-RV1106_Luckfox_Pico_Pro_Max-IPC.mk
+++ b/project/cfg/BoardConfig_IPC/BoardConfig-SPI_NAND-Buildroot-RV1106_Luckfox_Pico_Pro_Max-IPC.mk
@@ -27,7 +27,7 @@ export RK_BOOT_MEDIUM=spi_nand
 export RK_UBOOT_DEFCONFIG_FRAGMENT=rk-sfc.config
 
 # specify post.sh for delete/overlay files
-export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
+# export RK_PRE_BUILD_OEM_SCRIPT=rv1103-spi_nor-post.sh
 
 # config partition in environment
 # RK_PARTITION_CMD_IN_ENV format:


### PR DESCRIPTION
When building rootfs with builroot,user encountered a missing oem partition，