### PR TITLE
fix the error of extra symbols in luckfox-pico plus DTS

### DIFF
--- a/sysdrv/source/kernel/arch/arm/boot/dts/rv1103g-luckfox-pico-plus.dts
+++ b/sysdrv/source/kernel/arch/arm/boot/dts/rv1103g-luckfox-pico-plus.dts
@@ -12,7 +12,6 @@
 / {
 	model = "Luckfox Pico Plus";
 	compatible = "rockchip,rv1103g-38x38-ipc-v10", "rockchip,rv1103";
-	};
 };
 
 /**********SFC**********/


### PR DESCRIPTION
 sysdrv:source:kernel:arch:arm:boot:dts:fix the error of extra symbols in luckfox-pico plus DTS