### PR TITLE
Partial bug fixes and optimization

### DIFF
--- a/sysdrv/source/mcu/.gitignore
+++ b/sysdrv/source/mcu/.gitignore
@@ -1,1 +1,1 @@
-./prebuilts/*
+prebuilts

--- a/sysdrv/tools/board/kernel/rv1106g-luckfox-pico-pro-max-fastboot.dts
+++ b/sysdrv/tools/board/kernel/rv1106g-luckfox-pico-pro-max-fastboot.dts
@@ -14,6 +14,15 @@
 	chosen {
 		bootargs = "loglevel=0 rootfstype=erofs rootflags=dax console=ttyFIQ0 root=/dev/rd0 snd_soc_core.prealloc_buffer_size_kbytes=16 coherent_pool=0 driver_async_probe=dwmmc_rockchip";
 	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+		work_led: work{
+			gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "activity";
+			default-state = "on";
+		};
+	};
 };
 
 /delete-node/ &thunder_boot_spi_nor;

--- a/sysdrv/tools/board/luckfox_config/luckfox-config
+++ b/sysdrv/tools/board/luckfox_config/luckfox-config
@@ -208,26 +208,19 @@ function luckfox_load_cfg() {
 
 	# SDMMC
 	value=$(luckfox_get_pin_cfg "SDMMC_ENABLE")
-	if [ -z "$value" ] && [ "$LUCKFOX_CHIP_MEDIA_CLASS" == "spi_nand" ] && [ "$LUCKFOX_CHIP_MEDIA" == "Luckfox Pico Plus" ]; then
-		luckfox_set_pin_mark "GPIO3_A1" 1
-		luckfox_set_pin_mark "GPIO3_A3" 1
-		luckfox_set_pin_mark "GPIO3_A2" 1
-		luckfox_set_pin_mark "GPIO3_A4" 1
-		luckfox_set_pin_mark "GPIO3_A5" 1
-		luckfox_set_pin_mark "GPIO3_A7" 1
-		luckfox_set_pin_mark "GPIO3_A6" 1
-	elif [ "$LUCKFOX_CHIP_MEDIA_CLASS" == "sdmmc" ] && [ "$LUCKFOX_CHIP_MEDIA" == "Luckfox Pico Plus" ]; then
-		luckfox_set_pin_mark "GPIO3_A1" 1
-		luckfox_set_pin_mark "GPIO3_A3" 1
-		luckfox_set_pin_mark "GPIO3_A2" 1
-		luckfox_set_pin_mark "GPIO3_A4" 1
-		luckfox_set_pin_mark "GPIO3_A5" 1
-		luckfox_set_pin_mark "GPIO3_A7" 1
-		luckfox_set_pin_mark "GPIO3_A6" 1
-	else
-		if [ -n "$value" ]; then
-			luckfox_sdmmc_app "$value"
+
+	if [ -z "$value" ]; then
+		if [ "$LUCKFOX_CHIP_MODEL" == "Luckfox Pico Plus" ]; then
+			luckfox_set_pin_mark "GPIO3_A1" 1
+			luckfox_set_pin_mark "GPIO3_A3" 1
+			luckfox_set_pin_mark "GPIO3_A2" 1
+			luckfox_set_pin_mark "GPIO3_A4" 1
+			luckfox_set_pin_mark "GPIO3_A5" 1
+			luckfox_set_pin_mark "GPIO3_A7" 1
+			luckfox_set_pin_mark "GPIO3_A6" 1
 		fi
+	else
+		luckfox_sdmmc_app "$value"
 	fi
 
 	# Create global variables by comparing cfg files
@@ -1274,6 +1267,16 @@ function luckfox_check_i2c() {
 		#check CSI status
 		if [ "$i2c_main" == 4 ]; then
 			csi_status=$(luckfox_get_pin_cfg "CSI_ENABLE")
+			# process default status
+			if [ -z "$csi_status" ]; then
+				# CSI I2C is not enabled on Ultra models by default
+				if [ "$LUCKFOX_CHIP_MODEL" == "Luckfox Pico Ultra" ] || [ "$LUCKFOX_CHIP_MODEL" == "Luckfox Pico Ultra W" ]; then
+					"$csi_status" = 0
+				else
+					"$csi_status" = 1
+				fi
+			fi
+
 			if [ "$csi_status" == 1 ]; then
 				luckfox_result_handle "$LF_ERR" "CSI is enable,Can't config I2C4"
 			fi


### PR DESCRIPTION
sysdrv:source:mcu:.gitignore:Cancel compiler synchronization to the repository
sysdrv:tools:board:kernel:rv1106-luckfox-pico-pro-max-fastboot.dts:Add kernel LED blinking configuration sysdrv:tools:board:luckfox_config:luckfox-config:Add conflict warnings for SDMMC pin multiplexing on Luckfox Pico Plus, optimize I2C4 multiplexing checks