### PR TITLE
[pico pro max]Fix vdd_arm regulator and update OPP points

### DIFF
--- a/sysdrv/source/kernel/arch/arm/boot/dts/rv1106-luckfox-pico-pro-max-ipc.dtsi
+++ b/sysdrv/source/kernel/arch/arm/boot/dts/rv1106-luckfox-pico-pro-max-ipc.dtsi
@@ -43,11 +43,10 @@
 	vdd_arm: vdd-arm {
 		compatible = "regulator-fixed";
 		regulator-name = "vdd_arm";
-		regulator-min-microvolt = <800000>;
-		regulator-max-microvolt = <1000000>;
-		regulator-init-microvolt = <900000>;
 		regulator-always-on;
 		regulator-boot-on;
+		regulator-min-microvolt = <900000>;
+		regulator-max-microvolt = <900000>;
 	};
 	leds: leds {
 		compatible = "gpio-leds";
@@ -55,7 +54,7 @@
 			gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "activity";
 			default-state = "on";
-		};	
+		};
 	};
 
 	// DHT11
@@ -87,6 +86,29 @@
 /***************************** CPU ********************************/
 &cpu0 {
 	cpu-supply = <&vdd_arm>;
+};
+
+&cpu0_opp_table {
+		opp-408000000 {
+			opp-microvolt = <900000 900000 900000>;
+		};
+		opp-600000000 {
+			opp-microvolt = <900000 900000 900000>;
+		};
+		opp-816000000 {
+			opp-microvolt = <900000 900000 900000>;
+			opp-suspend;
+		};
+		opp-1104000000 {
+			opp-microvolt = <900000 900000 900000>;
+		};
+		opp-1200000000 {
+			opp-microvolt = <900000 900000 900000>;
+		};
+		/delete-node/ opp-1296000000;
+		/delete-node/ opp-1416000000;
+		/delete-node/ opp-1512000000;
+		/delete-node/ opp-1608000000;
 };
 
 /***************************** ADC ********************************/


### PR DESCRIPTION
- Adjust vdd_arm regulator voltage to fixed 0.9 volts
- Modify CPU OPP table to set all voltage points to 0.9 microvolts
- Remove higher frequency OPP nodes (1296MHz, 1416MHz, 1512MHz, 1608MHz)

These changes ensure stable voltage supply to the ARM core and align OPP points accordingly.