### PR TITLE
fix(luckfox-config): handle duplicate alias emission from CONFIG_DTC_SYMBOLS

### DIFF
--- a/project/cfg/BoardConfig_IPC/overlay/overlay-luckfox-config/usr/bin/luckfox-config
+++ b/project/cfg/BoardConfig_IPC/overlay/overlay-luckfox-config/usr/bin/luckfox-config
@@ -808,7 +808,11 @@ function luckfox_get_device_name() {
 	local device_node="$1"
 	local device_node_name
 
-	device_node_name=$(grep "$device_node =" $LUCKFOX_FDT_DUMP_TXT | awk '{print $3}' | sed 's/["";]//g')
+	# head -1 because kernels with CONFIG_DTC_SYMBOLS=y emit each alias
+	# twice (once under /aliases, once under /__symbols__); without this
+	# the device-ref in the generated DTS overlay spans two lines and
+	# dtc fails with "syntax error" / "Unable to parse input tree".
+	device_node_name=$(grep "$device_node =" $LUCKFOX_FDT_DUMP_TXT | head -1 | awk '{print $3}' | sed 's/["";]//g')
 	echo "$device_node_name"
 }
 


### PR DESCRIPTION
### Summary

`luckfox_get_device_name()` in `/usr/bin/luckfox-config` looks up a DT node path by grepping `/tmp/.fdt_dump.txt` for the alias name. On kernels built with `CONFIG_DTC_SYMBOLS=y` (the setting shipped by the stock `luckfox_rv1106_linux_defconfig`, enabled to support `OF_OVERLAY` / `OF_DTBO`), each alias string is emitted **twice** — once under `/aliases` and once under `/__symbols__`.

The grep therefore returns two lines. The caller splices that multi-line string straight into a dtbo template:

~~~dts
/dts-v1/;
/plugin/;

&{$i2c_device_name}{           <-- becomes &{/i2c@ff460000
        status="okay";                        /i2c@ff460000}{
        ...                                   ^^^^^^^^^^^^^
};                                            syntax error
~~~

`dtc -I dts -O dtb` then fails:

~~~
Error: /tmp/.overlay.dts:5.1-2 syntax error
FATAL ERROR: Unable to parse input tree
cat: can't open '/tmp/.overlay.dtbo': No such file or directory
Complete configuration loading
~~~

The script still exits rc=0 and prints \`Complete configuration loading\`, so the user sees no error — but no overlay is registered and \`/dev/i2c-3\` / \`/dev/spidev*\` / \`/dev/ttyS*\` never appears.

### Fix

Pipe the grep through \`head -1\`. The \`/aliases\` entry is the authoritative one; \`/__symbols__\` carries the same string for overlay resolver purposes and is structurally redundant here.

### Repro

1. Kernel built with \`CONFIG_DTC_SYMBOLS=y\` (stock defconfig).
2. \`echo I2C3_M0_STATUS=1 >> /etc/luckfox.cfg\`
3. \`luckfox-config load\`
4. Observe the dtc error in the output; \`ls /sys/kernel/config/device-tree/overlays/\` is empty; \`/dev/i2c-3\` does not appear.

### Test plan

- [x] Reproduced on Luckfox Pico Pro Max, kernel 5.10.160 with \`CONFIG_DTC_SYMBOLS=y\`.
- [x] With patch applied: overlay registers, \`/dev/i2c-3\` enumerates, \`i2cdetect -y 3\` shows the attached devices.
- [x] No behaviour change on kernels without \`DTC_SYMBOLS\` (single-match case passes through \`head -1\` unchanged).